### PR TITLE
fix: add device passing back for unprivileged

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,11 @@ services:
       - WAYVNC_ENABLE_AUTH=true
       - WAYVNC_USERNAME=wayvnc
       - WAYVNC_PASSWORD=wayvnc
-    cap_add:
-      - SYS_ADMIN
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    security_opt:
+      - seccomp:unconfined
 
 volumes:
   swayvnc-wayvnc-certs:


### PR DESCRIPTION
in #7, I removed the `privileged: true` for security concerns, but that requires the device passing to be added back for amd gpus.

I followed this [doc](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/how-to/docker.html) to add it back.

or maybe add `privileged: true` back, I dont know.